### PR TITLE
added parent set selection

### DIFF
--- a/src/resources/utils/constants.ts
+++ b/src/resources/utils/constants.ts
@@ -9,6 +9,7 @@ export const ADD_VARIABLE_TO_STATE_PLACEHOLDER = 'Enter Variable Name';
 export const CREATE_REDUCER_PLACE_HOLDER = 'Enter Reducer Name';
 export const CREATE_MIDDLEWARE_PLACE_HOLDER = 'Enter Middleware Name';
 export const CREATE_ACTION_PLACE_HOLDER = 'Enter Action File Name';
+export const SELECT_PARENT_SET = 'Select Parent Set';
 export const NAME_ERROR_MESSAGE = 'Please use name without space. Consider using "_"';
 export const VARIABLE_NAME_ERROR_MESSAGE = 'Please use name without space. Consider using camelCase';
 export const NAME_REG_EXP = /[`0-9 ~!@#$%^&*()|+\-=?;:'",.<>\{\}\[\]\\\/]/;


### PR DESCRIPTION
-----ISSUES-----
My `PARENT_PATH` variable disappeared twice because:
- i cloned repository to other device
- i changed default name of parent set directory from `store` to `redux`

-----PROBLEM-----
then there is no option to set `PARENT_PATH` again once you loose it, and you see a message `Parent set not found.`

-----PROPOSED SOLUTION-----
Because the "Create Set" is the only command making change in parent `.state.dart` file, i added option inside it to reselect parent set file in given directory.

-----DOUBTS-----
User can select incorrect `.state.dart` file because of for ex. miss click. Meaby its good idea to create a comand in Command Palette to rescan whole file tree and give on option to choose a parent.