### PR TITLE
Added 'select parent set' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Refer the article to know about the extension.
 | Parent Set    | Its a parent of all Set. Its configured by Us as a parent          |
 | Auto Import   | When you create a set it will automatically imported to Parent Set |
 
+## Command Palette
+
+| Command           | Description                                                    |
+| :---------------- | :------------------------------------------------------------- |
+| Select Parent Set | Select parent set from file tree.                              |
+
 ## Upcoming Features
 
 1.  Tree view of states - Explorer View

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
 		"onCommand:flutter-redux-gen.createMiddleware",
 		"onCommand:flutter-redux-gen.createAction",
 		"onCommand:flutter-redux-gen.createParentSet",
-		"onCommand:flutter-redux-gen.createVariableInState"
+		"onCommand:flutter-redux-gen.createVariableInState",
+		"onCommand:flutter-redux-gen.selectParentSet"
 	],
 	"main": "./out/extension.js",
 	"contributes": {
@@ -82,6 +83,11 @@
 				"command": "flutter-redux-gen.createVariableInState",
 				"title": "Add Variable to State",
 				"category": "Flutter Redux Gen"
+			},
+			{
+				"command": "flutter-redux-gen.selectParentSet",
+				"title": "Select Parent Set",
+				"category": "Flutter Redux Gen"
 			}
 		],
 		"menus": {
@@ -112,6 +118,9 @@
 				{
 					"command": "flutter-redux-gen.createVariableInState",
 					"when": "false"
+				},
+				{
+					"command": "flutter-redux-gen.selectParentSet"
 				}
 			],
 			"editor/context": [{

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { CREATE_STATE_PLACE_HOLDER, NAME_ERROR_MESSAGE, CREATE_ACTION_PLACE_HOLDER, CREATE_MIDDLEWARE_PLACE_HOLDER, CREATE_REDUCER_PLACE_HOLDER, NAME_REG_EXP, DEFAULT_NAME, STATE_EXTENSION, REDUCER_EXTENSION, MIDDLEWARE_EXTENSION, ACTION_EXTENSION, ADD_VARIABLE_TO_STATE_PLACEHOLDER, VARIABLE_NAME_ERROR_MESSAGE, SELECT_PARENT_SET } from './resources/utils/constants';
+import { CREATE_STATE_PLACE_HOLDER, NAME_ERROR_MESSAGE, CREATE_ACTION_PLACE_HOLDER, CREATE_MIDDLEWARE_PLACE_HOLDER, CREATE_REDUCER_PLACE_HOLDER, NAME_REG_EXP, DEFAULT_NAME, STATE_EXTENSION, REDUCER_EXTENSION, MIDDLEWARE_EXTENSION, ACTION_EXTENSION, ADD_VARIABLE_TO_STATE_PLACEHOLDER, VARIABLE_NAME_ERROR_MESSAGE, SELECT_PARENT_SET, NOT_FOUND_ANY_SET_FILE, NO_FOLDER_IN_WORKSPACE_FOUND, STATE_FILE_RELATIVE_PATTERN, CURRENT_PARENT, SUCCESFULLY_SET_PARENT } from './resources/utils/constants';
 import { getStateGenCode, addVariableToState } from './resources/gen/state';
 import { getFilePath } from './resources/utils/utils';
 import { getReducerGenCode } from './resources/gen/reducer';
@@ -228,6 +228,39 @@ export function activate(context: vscode.ExtensionContext): void {
 			});
 			nameField.show();
 		}
+	});
+
+	vscode.commands.registerCommand('flutter-redux-gen.selectParentSet', async (args) => {
+		const folders = vscode.workspace.workspaceFolders;
+		if (!folders) {
+			return vscode.window.showErrorMessage(NO_FOLDER_IN_WORKSPACE_FOUND);
+		}
+
+		let sets: vscode.Uri[] = [];
+		const fillSetsArray = folders.map(folder =>
+			vscode.workspace.findFiles(
+				new vscode.RelativePattern(folder, STATE_FILE_RELATIVE_PATTERN),
+			).then(files => sets.push(...files))
+		);
+
+		await Promise.all(fillSetsArray);
+
+		if (!sets.length) {
+			return vscode.window.showErrorMessage(NOT_FOUND_ANY_SET_FILE);
+		}
+
+		const parent = getParentName(context);
+		const placeHolder = parent ? CURRENT_PARENT.replace('<FILE>', parent) : '';
+
+		vscode.window.showQuickPick(sets.map(set => set.path), { title: SELECT_PARENT_SET, placeHolder })
+			.then(set => {
+				if (!set) {
+					return;
+				}
+
+				saveParentSet(path.dirname(set), path.basename(set, STATE_EXTENSION), context);
+				vscode.window.showInformationMessage(SUCCESFULLY_SET_PARENT.replace('<FILE>', path.basename(set)));
+			});
 	});
 
 	context.subscriptions.push(createParentSet);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -236,7 +236,7 @@ export function activate(context: vscode.ExtensionContext): void {
 			return vscode.window.showErrorMessage(NO_FOLDER_IN_WORKSPACE_FOUND);
 		}
 
-		let sets: vscode.Uri[] = [];
+		const sets: vscode.Uri[] = [];
 		const fillSetsArray = folders.map(folder =>
 			vscode.workspace.findFiles(
 				new vscode.RelativePattern(folder, STATE_FILE_RELATIVE_PATTERN),

--- a/src/resources/utils/constants.ts
+++ b/src/resources/utils/constants.ts
@@ -12,4 +12,10 @@ export const CREATE_ACTION_PLACE_HOLDER = 'Enter Action File Name';
 export const SELECT_PARENT_SET = 'Select Parent Set';
 export const NAME_ERROR_MESSAGE = 'Please use name without space. Consider using "_"';
 export const VARIABLE_NAME_ERROR_MESSAGE = 'Please use name without space. Consider using camelCase';
+export const NOT_FOUND_ANY_SET_FILE = `Not found any file with '${STATE_EXTENSION}' extension.`;
+export const NO_FOLDER_IN_WORKSPACE_FOUND = 'There is no folder in workspace.';
+export const CURRENT_PARENT = `Current parent is '<FILE>${STATE_EXTENSION}'`;
+export const SUCCESFULLY_SET_PARENT = `Succesfully set '<FILE>' as parent.`;
+
 export const NAME_REG_EXP = /[`0-9 ~!@#$%^&*()|+\-=?;:'",.<>\{\}\[\]\\\/]/;
+export const STATE_FILE_RELATIVE_PATTERN = `**/*.state.dart`;


### PR DESCRIPTION
----- DESCRIPTION -----
Added command to `select parent set` from workspace file tree.
Fixed readme with `Command Palette` table section.

----- WHY -----
Feature covers the problem, where user lost `PARENT_NAME` variable or (more important) incorrect one is chosen.
Could be useful (in my case ^^) in monorepo project which contains more than one parent set.