### PR TITLE
fixed adding variable to wrapped copyWith function

### DIFF
--- a/src/resources/gen/state.ts
+++ b/src/resources/gen/state.ts
@@ -83,8 +83,15 @@ function _addVariableToState(path: string, varType: string, varName: string) {
 
 	// Add Var CopyWith Method
 	const copyWithText = `${varType}? ${varName},`;
-	const indexOfCopyWithLine = updatedStateCodeList.findIndex(value => value.includes(`${stateName} copyWith({`));
-	const indexOfInitialInsert = updatedStateCodeList[indexOfCopyWithLine].indexOf(`${stateName} copyWith({`) + `${stateName} copyWith({`.length;
+	let indexOfCopyWithLine = updatedStateCodeList.findIndex(value => value.includes(`${stateName} copyWith({`));
+	let indexOfInitialInsert: number;
+	if (indexOfCopyWithLine !== -1) {
+		indexOfInitialInsert = updatedStateCodeList[indexOfCopyWithLine].indexOf(`${stateName} copyWith({`) + `${stateName} copyWith({`.length;
+	} else {
+		indexOfCopyWithLine = updatedStateCodeList.findIndex(value => value.includes(`${stateName} copyWith(`)) + 1;
+		indexOfInitialInsert = updatedStateCodeList[indexOfCopyWithLine].indexOf(`{`) + 1;
+	}
+	
 	updatedStateCodeList[indexOfCopyWithLine] = updatedStateCodeList[indexOfCopyWithLine].slice(0, indexOfInitialInsert) + copyWithText + updatedStateCodeList[indexOfCopyWithLine].slice(indexOfInitialInsert);
 
 	// Add Var CopyWith Res Method


### PR DESCRIPTION
Native dart linter can break copyWith function like:

<img width="457" alt="Screenshot 2022-01-31 at 10 29 30" src="https://user-images.githubusercontent.com/14834811/151770677-227e8334-a9f4-4c7f-a1b2-4cc50d29d342.png">

and then, `indexOfCopyWithLine` is `-1` once there is no line with `copyWith({` substring and `updatedStateCodeList[-1].indexOf(...` throws error.